### PR TITLE
replace path.skip() with path.stop()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export default declare((_api, opts) => {
       }
     }
 
-    path.skip()
+    path.stop()
     path.replaceWith(t.inherits(t.objectExpression(properties), node))
   }
 


### PR DESCRIPTION
This fixes an issue I was having getting

Maximum call stack size exceeded

errors on any usage, including the example.

{ RangeError: /src/test.js: Maximum call stack size exceeded
    at RegExp.test (<anonymous>)
    at WriteStream.getColorDepth (internal/tty.js:133:22)
    at Console.(anonymous function) (console.js:183:16)
    at Console.(anonymous function) (console.js:190:40)
    at Console.log (console.js:202:31)
    at HandleObjectExpression (/node_modules/babel-plugin-transform-strip-block/dist-node/index.js:68:15)
    at PluginPass.ObjectExpression (/node_modules/babel-plugin-transform-strip-block/dist-node/index.js:152:9)
    at newFn (/node_modules/@babel/traverse/lib/visitors.js:179:21)
    at NodePath._call (/node_modules/@babel/traverse/lib/path/context.js:53:20)
    at NodePath.call (/node_modules/@babel/traverse/lib/path/context.js:40:17) code: 'BABEL_TRANSFORM_ERROR' }

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I'm not sure if this would break anything, but it didn't work at all for me without it and now it works great.